### PR TITLE
Be explicit about load order

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,21 +1,21 @@
 var fs = require("fs");
 
-// Initializer Loader
+// Load files / finalizers alphabetically from a folder
 // ------------------
 
 var Loader = {
   load: function(folder){
-    var initializers = [];
+    var files = [];
     folder = fixFolderName(folder);
 
-    fs.readdirSync(folder).forEach(function(file){
+    fs.readdirSync(folder).sort().forEach(function(file){
       if (!isJSFile(file)){ return; }
 
-      var init = require(folder + file);
-      initializers.push(init);
+      var script = require(folder + file);
+      files.push(script);
     });
 
-    return initializers;
+    return files;
   }
 };
 
@@ -25,7 +25,7 @@ var Loader = {
 function fixFolderName(folder){
   var index = folder.lastIndexOf("/");
   var length = folder.length;
-  
+
   if (index !== length){
     folder = folder + "/";
   }

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ folder in your project structure:
 </pre>
 
 In the `initializers` folder, place any `.js` files you want to
-run as an initializer.
+run as an initializer. These files will be run in sorted alphabetical order.
 
 In the `finalizers` fodler, place any `.js` files that should be
 run just before the application shuts down or exits.

--- a/specs/finalizers.specs.js
+++ b/specs/finalizers.specs.js
@@ -3,12 +3,13 @@ var Nanit = require("../lib");
 
 describe("file finalizers", function(){
   var finalizerFolder = path.resolve(process.cwd(), "specs", "finalizers");
-  
+
   describe("when loading finalizers from files", function(){
     var completed;
 
     beforeEach(function(){
       completed = false;
+      global.fins = [];
       global.fin1 = false;
       global.fin2 = false;
 
@@ -21,6 +22,11 @@ describe("file finalizers", function(){
     it("should run all the finalizers", function(){
       expect(global.fin1).toBe(true);
       expect(global.fin2).toBe(true);
+    });
+
+    it("should run the finalizers in sorted alphabetical order", function () {
+      expect(global.fins[0]).toEqual('fin1')
+      expect(global.fins[1]).toEqual('fin2')
     });
 
     it("should complete finalizer process", function(){

--- a/specs/finalizers/fin1.js
+++ b/specs/finalizers/fin1.js
@@ -1,4 +1,5 @@
 module.exports = function(arg, next){
   global.fin1 = true;
+  global.fins.push('fin1');
   next();
 };

--- a/specs/finalizers/fin2.js
+++ b/specs/finalizers/fin2.js
@@ -1,4 +1,5 @@
 module.exports = function(arg, next){
   global.fin2 = true;
+  global.fins.push('fin2');
   next();
 };

--- a/specs/initializers.specs.js
+++ b/specs/initializers.specs.js
@@ -3,12 +3,13 @@ var Nanit = require("../lib");
 
 describe("file initializers", function(){
   var initializerFolder = path.resolve(process.cwd(), "specs", "initializers");
-  
+
   describe("when loading initializers from files", function(){
     var completed;
 
     beforeEach(function(){
       completed = false;
+      global.inits = [];
       global.init1 = false;
       global.init2 = false;
 
@@ -21,6 +22,12 @@ describe("file initializers", function(){
     it("should run all the initializers", function(){
       expect(global.init1).toBe(true);
       expect(global.init2).toBe(true);
+    });
+
+    it("should run the initializers in sorted alphabetical order", function () {
+      expect(global.inits.length).toEqual(2);
+      expect(global.inits[0]).toEqual('init1')
+      expect(global.inits[1]).toEqual('init2')
     });
 
     it("should complete initialization process", function(){

--- a/specs/initializers/init1.js
+++ b/specs/initializers/init1.js
@@ -1,4 +1,5 @@
 module.exports = function(arg, next){
   global.init1 = true;
+  global.inits.push('init1');
   next();
 };

--- a/specs/initializers/init2.js
+++ b/specs/initializers/init2.js
@@ -1,4 +1,5 @@
 module.exports = function(arg, next){
   global.init2 = true;
+  global.inits.push('init2');
   next();
 };


### PR DESCRIPTION
Added a call to `.sort()` the results of `fs.readDirSync` and made
a note in the documentation and specs about this behavior so that a developer
can use this knowledge when she wants to run certain tasks in a specific
order.

This was the first thing I thought before deciding if this project would be suitable for my needs and I noticed there was an existing issue #6 
